### PR TITLE
Adds reverse check of indexOnly to delete not-anymore-indexable documents.

### DIFF
--- a/src/EloquentSubscriber.php
+++ b/src/EloquentSubscriber.php
@@ -19,8 +19,11 @@ class EloquentSubscriber
 
         /** @var \AlgoliaSearch\Index $index */
         foreach ($this->modelHelper->getIndices($model) as $index) {
+
             if ($this->modelHelper->indexOnly($model, $index->indexName)) {
                 $index->addObject($this->modelHelper->getAlgoliaRecord($model), $this->modelHelper->getKey($model));
+            } else if ($this->modelHelper->wouldBeIndexed($model, $index->indexName)) {
+                $index->deleteObject($this->modelHelper->getObjectId($model));
             }
         }
 

--- a/src/ModelHelper.php
+++ b/src/ModelHelper.php
@@ -49,9 +49,11 @@ class ModelHelper
             return false;
         }
 
-        $model->setRawAttributes($model->getOriginal());
+        $cloned = clone $model;
 
-        return $model->indexOnly($index_name) === true;
+        $cloned->setRawAttributes($cloned->getOriginal());
+
+        return $cloned->indexOnly($index_name) === true;
     }
 
     public function getObjectId(Model $model)

--- a/src/ModelHelper.php
+++ b/src/ModelHelper.php
@@ -43,6 +43,17 @@ class ModelHelper
         return !method_exists($model, 'indexOnly') || $model->indexOnly($index_name);
     }
 
+    public function wouldBeIndexed(Model $model, $index_name)
+    {
+        if (! method_exists($model, 'indexOnly')) {
+            return false;
+        }
+
+        $model->setRawAttributes($model->getOriginal());
+
+        return $model->indexOnly($index_name) === true;
+    }
+
     public function getObjectId(Model $model)
     {
         return $model->{$this->getObjectIdKey($model)};


### PR DESCRIPTION
In my company we use `indexOnly()` to determine if an article should be published in the product list.

Since `EloquentSubscriber` triggers an index removal only when an Eloquent model is deleted, I have found the need to add a reverse check of `indexOnly()` function to see if, during an update, a Model was able to get indexed prior the new updates, but not anymore after them.

If the check is true, it deletes the document from the index.