### PR TITLE
Add indexName parameter to record getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,42 @@ public function getAlgoliaRecord()
 }
 ```
 
+### Dynamic record attributes
 
+Similar to [targeting multiple indices](#target-multiple-indexes), the `getAlgoliaRecord` method optionally takes an index name as its first parameter. This is useful if have more than one index and you want to shape models differently based on the index they'll be inserted into.
+
+See an example of storing different contacts based on the index below:
+
+```php
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+use AlgoliaSearch\Laravel\AlgoliaEloquentTrait;
+
+class Contact extends Model
+{
+    use AlgoliaEloquentTrait;
+
+    public $indices = [
+        'private_contacts',
+        'public_contacts'
+    ];
+
+    public function getAlgoliaRecord($indexName)
+    {
+        $extraData = [];
+
+        if ($indexName === 'private_contacts') {
+            $extraData = [
+                'personal_number' => $this->personal_number,
+                'home_address' => $this->home_address
+            ];
+        }
+
+        return array_merge($this->toArray(), $extraData);
+    }
+}
+```
 
 ## Indexing
 

--- a/src/AlgoliaEloquentTrait.php
+++ b/src/AlgoliaEloquentTrait.php
@@ -31,7 +31,7 @@ trait AlgoliaEloquentTrait
 
                 foreach ($models as $model) {
                     if ($modelHelper->indexOnly($model, $index->indexName)) {
-                        $records[] = $model->getAlgoliaRecordDefault();
+                        $records[] = $model->getAlgoliaRecordDefault($index->indexName);
                     }
                 }
 
@@ -223,7 +223,7 @@ trait AlgoliaEloquentTrait
     /**
      * Methods.
      */
-    public function getAlgoliaRecordDefault()
+    public function getAlgoliaRecordDefault($indexName = null)
     {
         /** @var \AlgoliaSearch\Laravel\ModelHelper $modelHelper */
         $modelHelper = App::make('\AlgoliaSearch\Laravel\ModelHelper');
@@ -231,7 +231,11 @@ trait AlgoliaEloquentTrait
         $record = null;
 
         if (method_exists($this, static::$methodGetName)) {
-            $record = $this->{static::$methodGetName}();
+            if (is_null($indexName)) {
+                $indexName = $modelHelper->getIndices($this)[0]->indexName;
+            }
+
+            $record = $this->{static::$methodGetName}($indexName);
         } else {
             $record = $this->toArray();
         }
@@ -253,7 +257,7 @@ trait AlgoliaEloquentTrait
         /** @var \AlgoliaSearch\Index $index */
         foreach ($indices as $index) {
             if ($modelHelper->indexOnly($this, $index->indexName)) {
-                $index->addObject($this->getAlgoliaRecordDefault());
+                $index->addObject($this->getAlgoliaRecordDefault($index->indexName));
             }
         }
     }

--- a/src/EloquentSubscriber.php
+++ b/src/EloquentSubscriber.php
@@ -21,7 +21,7 @@ class EloquentSubscriber
         foreach ($this->modelHelper->getIndices($model) as $index) {
 
             if ($this->modelHelper->indexOnly($model, $index->indexName)) {
-                $index->addObject($this->modelHelper->getAlgoliaRecord($model), $this->modelHelper->getKey($model));
+                $index->addObject($this->modelHelper->getAlgoliaRecord($model, $index->indexName), $this->modelHelper->getKey($model));
             } else if ($this->modelHelper->wouldBeIndexed($model, $index->indexName)) {
                 $index->deleteObject($this->modelHelper->getObjectId($model));
             }

--- a/src/ModelHelper.php
+++ b/src/ModelHelper.php
@@ -122,8 +122,8 @@ class ModelHelper
         return $indices;
     }
 
-    public function getAlgoliaRecord(Model $model)
+    public function getAlgoliaRecord(Model $model, $indexName = null)
     {
-        return $model->getAlgoliaRecordDefault();
+        return $model->getAlgoliaRecordDefault($indexName);
     }
 }

--- a/tests/AlgoliaEloquentTraitTest.php
+++ b/tests/AlgoliaEloquentTraitTest.php
@@ -6,6 +6,7 @@ use AlgoliaSearch\Tests\Models\Model2;
 use AlgoliaSearch\Tests\Models\Model4;
 use AlgoliaSearch\Tests\Models\Model6;
 use AlgoliaSearch\Tests\Models\Model7;
+use AlgoliaSearch\Tests\Models\Model8;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
 use Mockery;
@@ -29,6 +30,20 @@ class AlgoliaEloquentTraitTest extends TestCase
         $this->assertEquals(array('id2' => 1, 'objectID' => 1, 'id3' => 1, 'name' => 'test'), $model4->getAlgoliaRecordDefault());
     }
 
+    public function testGetAlgoliaRecordBasedOnIndex()
+    {
+        $model8 = new Model8();
+
+        $this->assertEquals(array('id' => 1, 'objectID' => 1, 'key' => 'someKey'), $model8->getAlgoliaRecordDefault('index1'));
+        $this->assertEquals(array('id' => 1, 'objectID' => 1, 'name' => 'someName'), $model8->getAlgoliaRecordDefault('index2'));
+    }
+
+    public function testGetAlgoliaRecordDefaultIfNoIndexProvided()
+    {
+        $model8 = new Model8();
+
+        $this->assertEquals(array('id' => 1, 'objectID' => 1, 'key' => 'someKey'), $model8->getAlgoliaRecordDefault());
+    }
     public function testPushToindex()
     {
         /** @var \AlgoliaSearch\Laravel\ModelHelper $realModelHelper */

--- a/tests/Models/Model8.php
+++ b/tests/Models/Model8.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace AlgoliaSearch\Tests\Models;
+
+use AlgoliaSearch\Laravel\AlgoliaEloquentTrait;
+use Illuminate\Database\Eloquent\Model;
+
+class Model8 extends Model
+{
+    use AlgoliaEloquentTrait;
+
+    public static $autoIndex = false;
+    public static $autoDelete = false;
+
+    protected $primaryKey = 'id';
+
+    public $indices = array('index1', 'index2');
+
+    public function __construct()
+    {
+        $this->id = 1;
+    }
+
+    public function getAlgoliaRecord($indexName)
+    {
+        if ($indexName === 'index1') {
+            $extraData = ['key' => 'someKey'];
+        } else {
+            $extraData = ['name' => 'someName'];
+        }
+
+        return array_merge($this->toArray(), $extraData);
+    }
+}


### PR DESCRIPTION
> Adding this method parameter to the record getter in the Model
> will allow consumers of the API to vary both keys and values
> of records conditionally.
> 
> Example use case would be to index a product in 3 different
> indices, and showing a different price in each.

Initially I needed this functionality for myself (for the reason above), and I didn't want to re-implement the same functionality as this library for such a trivial change.
After a bit of Googling I saw that somebody else stumbled on the same issue and found no answer (here: http://stackoverflow.com/questions/37994813/can-a-laravel-model-target-multiple-algolia-indices-with-different-attributes-fo).

It's a pretty specific use-case but it could help some people!

Lastly, this _should_ be a backwards-compatible change assuming the existing tests cover most (if not all) of the public surface area. All the the existing tests pass without modification, and new tests have been added to prevent regressions.

I currently bumped the version to 1.2.0 on my own fork. I think it's safe to do the same in yours without breaking anyones implementation, but that's for you to decide.